### PR TITLE
Skip analyzer agent for no preferences

### DIFF
--- a/supabase/functions/ingredicheck/analyzer.ts
+++ b/supabase/functions/ingredicheck/analyzer.ts
@@ -59,8 +59,13 @@ export async function analyze(ctx: Context) {
             }
         }
 
+        // Skip analyzer agent if user has no preferences set
+        const hasValidPreferences = requestBody.userPreferenceText && 
+                                    requestBody.userPreferenceText.trim() !== "" && 
+                                    requestBody.userPreferenceText.trim().toLowerCase() !== "none"
+        
         const ingredientRecommendations =
-            product.ingredients && product.ingredients.length !== 0
+            product.ingredients && product.ingredients.length !== 0 && hasValidPreferences
                 ? await ingredientAnalyzerAgent(ctx, product, requestBody.userPreferenceText)
                 : []
 


### PR DESCRIPTION
Skip calling the analyzer agent when users have no dietary preferences to reduce API costs, improve response time, and eliminate a known failure pattern.

The analyzer agent was being called even when preferences were "None" or empty, causing unnecessary API calls and failures, particularly for an edge case with "Organic Raw Cane Sugar". This change prevents these calls when there's nothing to analyze.

---
Linear Issue: [EIG-247](https://linear.app/eightinity/issue/EIG-247/do-not-call-analyzer-agent-if-user-has-not-set-any-preferences)

<a href="https://cursor.com/background-agent?bcId=bc-92bac424-a208-46e2-977a-44a81b4b3a18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92bac424-a208-46e2-977a-44a81b4b3a18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

